### PR TITLE
Split TORCharacterStatsModel health calculation by character category; fix champion HP and start-time crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,4 @@ EmAssetPackages/
 Tools/TranslationTool/translation_issues_report_*
 .claude
 tmpclaude-*
+CLAUDE.md

--- a/CSharpSourceCode/CharacterDevelopment/CareerSystem/CareerButton/CareerButtonHelper.cs
+++ b/CSharpSourceCode/CharacterDevelopment/CareerSystem/CareerButton/CareerButtonHelper.cs
@@ -13,6 +13,7 @@ using TOR_Core.CampaignMechanics.CustomResources;
 using TOR_Core.Extensions;
 using TOR_Core.Extensions.ExtendedInfoSystem;
 using TOR_Core.Extensions.UI;
+using static TOR_Core.Utilities.TORConstants;
 
 namespace TOR_Core.CharacterDevelopment.CareerSystem.CareerButton;
 
@@ -339,5 +340,41 @@ public static class CareerButtonHelper
 
         RefreshPartyAttributesUI();
         return true;
+    }
+
+    /// <summary>
+    /// Attributes read by TORCharacterStatsModel.CalculateHeroHealth. Only these carry over on promotion.
+    /// </summary>
+    private static readonly string[] HealthAttributes =
+    [
+        CharacterAttributes.TOUGH,
+        CharacterAttributes.EVERCHOSEN,
+        CharacterAttributes.BIG_BOSS,
+        CharacterAttributes.SHAMAN_BOSS,
+        CharacterAttributes.GIFT_OF_NURGLE
+    ];
+
+    /// <summary>
+    /// Gives a hero promoted out of the party roster the health an equivalent hero of its race already has.
+    /// </summary>
+    /// <remarks>
+    /// A promoted troop gets a runtime CharacterObject with no entry in tor_extendedunitproperties.xml, and
+    /// ExtendedInfoManager only copies template attributes for wanderers, so it inherits nothing from the troop
+    /// it came from. Call this last - the companion health passives need the hero already in the clan and party.
+    /// </remarks>
+    public static void ApplyPromotedHeroHealth(Hero hero, CharacterObject sourceTroop)
+    {
+        foreach (var attribute in sourceTroop.GetAttributes().Where(x => HealthAttributes.Contains(x)))
+        {
+            hero.AddAttribute(attribute);
+        }
+
+        //Tough is how the xml gives dwarf and orc heroes their racial baseline - every one of them carries it, no troop does.
+        if (hero.IsDwarf() || hero.IsOrc())
+        {
+            hero.AddAttribute(CharacterAttributes.TOUGH);
+        }
+
+        hero.HitPoints = hero.MaxHitPoints;
     }
 }

--- a/CSharpSourceCode/CharacterDevelopment/CareerSystem/CareerButton/GrailKnightCareerButtonBehavior.cs
+++ b/CSharpSourceCode/CharacterDevelopment/CareerSystem/CareerButton/GrailKnightCareerButtonBehavior.cs
@@ -57,6 +57,7 @@ namespace TOR_Core.CharacterDevelopment.CareerSystem.CareerButton
             AddCompanionAction.Apply(MobileParty.MainParty.ActualClan, hero);
             AddHeroToPartyAction.Apply(hero, MobileParty.MainParty);
             MobileParty.MainParty.MemberRoster.AddToCountsAtIndex(MobileParty.MainParty.MemberRoster.FindIndexOfTroop(_currentCharacterTemplate), -1);
+            CareerButtonHelper.ApplyPromotedHeroHealth(hero, _currentCharacterTemplate);
         }
 
         public override void ButtonClickedEvent(CharacterObject characterObject, bool isPrisoner = false, bool shiftClick = false)

--- a/CSharpSourceCode/CharacterDevelopment/CareerSystem/CareerButton/MercenaryCareerButtonBehavior.cs
+++ b/CSharpSourceCode/CharacterDevelopment/CareerSystem/CareerButton/MercenaryCareerButtonBehavior.cs
@@ -63,6 +63,7 @@ namespace TOR_Core.CharacterDevelopment.CareerSystem.Button
             AddCompanionAction.Apply(MobileParty.MainParty.ActualClan, hero);
             AddHeroToPartyAction.Apply(hero, MobileParty.MainParty);
             MobileParty.MainParty.MemberRoster.AddToCountsAtIndex(MobileParty.MainParty.MemberRoster.FindIndexOfTroop(_currentTemplate), -1);
+            CareerButtonHelper.ApplyPromotedHeroHealth(hero, _currentTemplate);
         }
 
         public override void ButtonClickedEvent(CharacterObject characterObject, bool isPrisoner = false, bool shiftClick = false)

--- a/CSharpSourceCode/Extensions/ExtendedInfoSystem/ExtendedInfoManager.cs
+++ b/CSharpSourceCode/Extensions/ExtendedInfoSystem/ExtendedInfoManager.cs
@@ -283,6 +283,7 @@ namespace TOR_Core.Extensions.ExtendedInfoSystem
                 TORCampaignEvents.Instance.OnHeroExtendedInfoCreated(hero);
                 if (hero.Template != null) InitializeTemplatedHeroStats(hero);
                 hero.AddCultureSpecificCustomResource(0);
+                hero.HitPoints = hero.MaxHitPoints; //the extended info feeds MaxHitpoints, so a hero whose info was only just created is still carrying the smaller pre-info value
             }
         }
 
@@ -363,6 +364,7 @@ namespace TOR_Core.Extensions.ExtendedInfoSystem
                     var info = new HeroExtendedInfo(hero.CharacterObject);
                     _heroInfos.Add(hero.GetInfoKey(), info);
                     hero.AddCultureSpecificCustomResource(0);
+                    hero.HitPoints = hero.MaxHitPoints; //the extended info feeds MaxHitpoints, so a hero whose info was only just created is still carrying the smaller pre-info value
                 }
             }
         }

--- a/CSharpSourceCode/Models/TORCharacterStatsModel.cs
+++ b/CSharpSourceCode/Models/TORCharacterStatsModel.cs
@@ -1,11 +1,9 @@
 using NLog;
-using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.GameComponents;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Core;
 using TaleWorlds.LinQuick;
-using TaleWorlds.Localization;
 using TaleWorlds.MountAndBlade;
 using TOR_Core.AbilitySystem;
 using TOR_Core.CampaignMechanics.CustomResources;
@@ -13,6 +11,7 @@ using TOR_Core.CampaignMechanics.TORCustomSettlement;
 using TOR_Core.CharacterDevelopment;
 using TOR_Core.CharacterDevelopment.CareerSystem;
 using TOR_Core.Extensions;
+using TOR_Core.Extensions.ExtendedInfoSystem;
 using TOR_Core.Items;
 using TOR_Core.Utilities;
 using static TOR_Core.Utilities.TORConstants;
@@ -21,16 +20,43 @@ namespace TOR_Core.Models
 {
     public class TORCharacterStatsModel : DefaultCharacterStatsModel
     {
+        /// <summary>
+        /// Which health rules a hero is subject to. Troops are the fourth category and never
+        /// reach here - they branch out at <see cref="CalculateHitPoints"/>.
+        /// </summary>
+        private enum HeroKind
+        {
+            Player,
+            Companion,
+            Lord
+        }
+
         public override int MaxCharacterTier => 9;
 
         public override ExplainedNumber MaxHitpoints(CharacterObject character, bool includeDescriptions = false)
         {
             var number = base.MaxHitpoints(character, includeDescriptions);
-            number = CalculateHitPoints(ref number, character);
+            CalculateHitPoints(ref number, character);
             return number;
         }
 
-        private ExplainedNumber CalculateHitPoints(ref ExplainedNumber number, CharacterObject character)
+        private void CalculateHitPoints(ref ExplainedNumber number, CharacterObject character)
+        {
+            AddRaceHealth(ref number, character);
+            if (character.IsHero)
+            {
+                CalculateHeroHealth(ref number, character.HeroObject);
+            }
+            else
+            {
+                CalculateTroopHealth(ref number, character);
+            }
+        }
+
+        /// <summary>
+        /// Race bonuses apply to every category alike - troop, player, companion and lord.
+        /// </summary>
+        private void AddRaceHealth(ref ExplainedNumber number, CharacterObject character)
         {
             if (character.IsMinotaur())
             {
@@ -40,6 +66,9 @@ namespace TOR_Core.Models
             {
                 number.Add(450f, TORTextHelper.GetTextObject("tor_stats_troll_bonus_text", "Troll bonus"));
             }
+            // Treemen carry the TreeSpirit attribute as well as the large_humanoid_monster race
+            // (tor_troopdefinitions.xml / tor_extendedunitproperties.xml), so this stays an else:
+            // they take the monster bonus instead of the dryad one, not both.
             if (character.IsTreeman())
             {
                 number.Add(1000f, TORTextHelper.GetTextObject("tor_stats_large_monster_text", "Large Monster"));
@@ -48,55 +77,48 @@ namespace TOR_Core.Models
             {
                 number.Add(100f, TORTextHelper.GetTextObject("tor_stats_dryad_bonus_text", "Dryad bonus"));
             }
-            if (character.IsHero)
+            if (character.IsDwarf())
             {
-                return CalculateHeroHealth(ref number, character.HeroObject);
+                number.Add(20, TORTextHelper.GetTextObject("tor_stats_dwarf_bonus_text", "Dwarf bonus"));
             }
-            else
+            if (character.IsGoblin())
             {
-                return CalculateTroopHealth(ref number, character);
+                number.Add(-20, TORTextHelper.GetTextObject("tor_stats_goblin_bonus_text", "Goblin frailty"));
+            }
+            if (character.IsOrc())
+            {
+                number.Add(40, TORTextHelper.GetTextObject("tor_stats_orc_bonus_text", "Orc bonus"));
             }
         }
 
-        private ExplainedNumber CalculateTroopHealth(ref ExplainedNumber number, CharacterObject character)
+        private void CalculateTroopHealth(ref ExplainedNumber number, CharacterObject character)
         {
+            var tierText = TORTextHelper.GetTextObject("tor_stats_troop_tier_text", "Troop tier");
             switch (character.Tier)
             {
                 case 0:
-                    number.Add(-15);
+                    number.Add(-15, tierText);
                     break;
                 case 1:
                 case 2:
                 case 3:
                     break;
                 case 4:
-                    number.Add(20);
+                    number.Add(20, tierText);
                     break;
                 default:
-                    number.Add(character.Tier * 10);
+                    number.Add(character.Tier * 10, tierText);
                     break;
             }
-            if (character.IsUndead() && !character.IsHero && !character.HasAttribute(CharacterAttributes.NECROMANCER_CHAMPION))
+            if (character.IsUndead() && !character.HasAttribute(CharacterAttributes.NECROMANCER_CHAMPION))
             {
-                number.Add(-25);
+                number.Add(-25, TORTextHelper.GetTextObject("tor_stats_undead_body_text", "Undead body"));
             }
 
-            if (character.IsDwarf())
-            {
-                number.Add(20);
-            }
-            if (character.IsGoblin())
-            {
-                number.Add(-20);
-            }
-            if (character.IsOrc())
-            {
-                number.Add(40);
-            }
-
+            // Must stay last: the champion's health is derived from the running total.
             if (character.HasAttribute(CharacterAttributes.NECROMANCER_CHAMPION))
             {
-                if (Mission.Current == null) return number;
+                if (Mission.Current == null) return;
                 var playerMainAgent = Mission.Current.MainAgent;
                 var value = playerMainAgent?.GetComponent<AbilityComponent>()?.CareerAbility?.Template?.ScaleVariable1;
                 if (value == null)
@@ -106,181 +128,218 @@ namespace TOR_Core.Models
                     else if (playerMainAgent.GetComponent<AbilityComponent>() == null) TORCommon.Log("Component null.", LogLevel.Info);
                     else if (playerMainAgent.GetComponent<AbilityComponent>().CareerAbility == null) TORCommon.Log("Career ability null.", LogLevel.Info);
                     else if (playerMainAgent.GetComponent<AbilityComponent>().CareerAbility.Template == null) TORCommon.Log("Template null.", LogLevel.Info);
-                    value = number.ResultNumber - 1;
+                    number = new ExplainedNumber(1f);
+                    return;
                 }
-                number.Add((int)value);
+                number.Add((int)value, TORTextHelper.GetTextObject("tor_stats_necromancer_champion_text", "Necromantic empowerment"));
             }
-
-            return number;
         }
 
-        private ExplainedNumber CalculateHeroHealth(ref ExplainedNumber number, Hero hero)
+        private void CalculateHeroHealth(ref ExplainedNumber number, Hero hero)
         {
             var info = hero.GetExtendedInfo();
             if (info != null)
             {
-                if (info.AcquiredAttributes.Contains("Tier1"))
+                AddCommonHeroHealth(ref number, hero, info);
+
+                switch (GetHeroKind(hero))
                 {
-                    number.Add(100, TORTextHelper.GetTextObject("tor_stats_tier1_text", "Tier1"));
-                }
-                else if (info.AcquiredAttributes.Contains("Tier2"))
-                {
-                    number.Add(150, TORTextHelper.GetTextObject("tor_stats_tier2_text", "Tier2"));
-                }
-                else if (info.AcquiredAttributes.Contains("Tier3"))
-                {
-                    number.Add(200, TORTextHelper.GetTextObject("tor_stats_tier3_text", "Tier3"));
-                }
-                else if (info.AcquiredAttributes.Contains("Tier4"))
-                {
-                    number.Add(300, TORTextHelper.GetTextObject("tor_stats_tier4_text", "Tier4"));
-                }
-                if (hero.IsVampire() && !hero.IsHumanPlayerCharacter)
-                {
-                    number.Add(100, TORTextHelper.GetTextObject("tor_stats_vampire_body_text", "Vampire body"));
+                    case HeroKind.Player:
+                        // Nothing player-exclusive outside AddAsraiHealth today.
+                        break;
+                    case HeroKind.Companion:
+                        AddCompanionCareerHealth(ref number, hero);
+                        break;
+                    case HeroKind.Lord:
+                        // AI heroes receive the common block only.
+                        break;
                 }
 
-                if (hero.HasAttribute(CharacterAttributes.EVERCHOSEN))
-                {
-                    number.Add(2000);
-                }
-
-                if (hero.IsOrion())
-                {
-                    number.Add(3000);
-                }
-
-                if (hero.IsDwarf())
-                {
-                    number.Add(20);
-                }
-                if (hero.IsGoblin())
-                {
-                    number.Add(-20);
-                }
-                if (hero.IsOrc())
-                {
-                    number.Add(40);
-                }
-
-                if (hero.HasAttribute(CharacterAttributes.TOUGH))
-                {
-                    number.Add(100);
-                }
-
-                if (hero.HasAnyCareer())
-                {
-                    CareerHelper.ApplyBasicCareerPassives(hero, ref number, PassiveEffectType.Health, false);
-                }
-
-                if (hero.IsPlayerCompanion)
-                {
-                    if (Hero.MainHero.HasCareerChoice("GuiltyByAssociationPassive3"))
-                    {
-                        var choice = TORCareerChoices.GetChoice("GuiltyByAssociationPassive3");
-                        number.Add(choice.GetPassiveValue(), choice.BelongsToGroup.Name);
-                    }
-
-                    if (Hero.MainHero.HasCareerChoice("CommanderPassive4"))
-                    {
-                        var choice = TORCareerChoices.GetChoice("CommanderPassive4");
-                        number.Add(choice.GetPassiveValue(), choice.BelongsToGroup.Name);
-                    }
-
-                    if (Hero.MainHero.HasCareerChoice("EnvoyOfTheLadyPassive2"))
-                    {
-                        if (hero.IsBretonnianKnight())
-                        {
-                            var choice = TORCareerChoices.GetChoice("EnvoyOfTheLadyPassive2");
-                            number.AddFactor(choice.GetPassiveValue(), choice.BelongsToGroup.Name);
-                        }
-                    }
-
-                    if (Hero.MainHero.HasCareerChoice("HolyCrusaderPassive2") &&
-                        hero.PartyBelongedTo == MobileParty.MainParty &&
-                        hero.IsBretonnianKnight())
-                    {
-                        var choice = TORCareerChoices.GetChoice("HolyCrusaderPassive2");
-                        var knightCompanions = MobileParty.MainParty.GetMemberHeroes().Where(knight => knight.IsBretonnianKnight());
-                        var extraHealth = knightCompanions.Count() * choice.GetPassiveValue();
-                        number.Add(extraHealth, choice.BelongsToGroup.Name);
-                    }
-
-                    if (Hero.MainHero.HasCareerChoice("ForHearthAndHomePassive2"))
-                    {
-                        var equipment = hero.CharacterObject.GetCharacterEquipment();
-                        var choice = TORCareerChoices.GetChoice("ForHearthAndHomePassive2");
-                        var extraHealth = equipment.WhereQ(item => item.HasAnyTrait()).Sum(_ => (int)choice.GetPassiveValue());
-
-                        number.Add(extraHealth, choice.BelongsToGroup.Name);
-                    }
-
-                    // BestofDaBestPassive4: Orc Big Bosses gain 100 health
-                    if (Hero.MainHero.HasCareerChoice("BestofDaBestPassive4"))
-                    {
-                        if (hero.HasAttribute(CharacterAttributes.BIG_BOSS))
-                        {
-                            var choice = TORCareerChoices.GetChoice("BestofDaBestPassive4");
-                            number.Add(choice.GetPassiveValue(), choice.BelongsToGroup.Name);
-                        }
-                    }
-
-                    // Orc Shaman: +70 HP for Shaman Boss companion
-                    if (Hero.MainHero.HasCareerChoice("GorkAnMorkAreWatchinPassive4"))
-                    {
-                        if (hero.HasAttribute(CharacterAttributes.SHAMAN_BOSS))
-                        {
-                            var choice = TORCareerChoices.GetChoice("GorkAnMorkAreWatchinPassive4");
-                            number.Add(choice.GetPassiveValue(), choice.BelongsToGroup.Name);
-                        }
-                    }
-
-                }
-
-                if (Hero.MainHero.Culture.StringId == TORConstants.Cultures.ASRAI && hero.PartyBelongedTo != null && (hero.PartyBelongedTo.IsMainParty || hero == Hero.MainHero))
-                {
-
-                    if (!Hero.MainHero.HasAttribute(CharacterAttributes.WE_WANDERER_SYMBOL))
-                    {
-                        var level = hero.PartyBelongedTo.LeaderHero.GetForestHarmonyLevel();
-                        switch (level)
-                        {
-                            case ForestHarmonyLevel.Harmony: break;
-                            case ForestHarmonyLevel.Unbound:
-                                number.AddFactor(ForestHarmonyHelper.HealthDebuffUnBound, GameTexts.FindText("tor_forest_harmony_level", ForestHarmonyLevel.Unbound.ToString()));
-                                break;
-                            case ForestHarmonyLevel.Bound:
-                                number.AddFactor(ForestHarmonyHelper.HealthDebuffBound, GameTexts.FindText("tor_forest_harmony_level", ForestHarmonyLevel.Bound.ToString()));
-                                break;
-                        }
-                    }
-
-                    var settlementBehavior = Campaign.Current.GetCampaignBehavior<TORCustomSettlementCampaignBehavior>();
-                    var list = settlementBehavior.GetUnlockedOakUpgradeCategory("WEHealthUpgrade");
-                    foreach (var attribute in list)
-                    {
-                        number.AddFactor(0.1f, new TextObject("Oak of Ages"));
-                    }
-
-
-                    if (Hero.MainHero.HasAttribute(CharacterAttributes.WE_WARDANCER_SYMBOL))
-                    {
-                        number.AddFactor(0.25f, ForestHarmonyHelper.TreeSymbolText("WEWardancerSymbol"));
-                    }
-
-                    if (hero == Hero.MainHero && Hero.MainHero.HasAttribute(CharacterAttributes.WE_DURTHU_SYMBOL))
-                    {
-                        number.AddFactor(0.10f);
-                    }
-
-                }
-
-
-                if (hero.HasAttribute(CharacterAttributes.GIFT_OF_NURGLE)) number.Add(20, new TextObject("Gift of Nurgle"));
+                // Keyed on party membership rather than hero kind: clan lords riding with the
+                // player are not IsPlayerCompanion but are still subject to forest harmony.
+                AddAsraiHealth(ref number, hero);
             }
+            AddUniversalHeroHealth(ref number, hero);
+        }
+
+        private static HeroKind GetHeroKind(Hero hero)
+        {
+            if (hero == Hero.MainHero) return HeroKind.Player;
+            if (hero.IsPlayerCompanion) return HeroKind.Companion;
+            return HeroKind.Lord;
+        }
+
+        /// <summary>
+        /// Applies to every hero that has extended info, whatever their kind.
+        /// </summary>
+        private void AddCommonHeroHealth(ref ExplainedNumber number, Hero hero, HeroExtendedInfo info)
+        {
+            if (info.AcquiredAttributes.Contains("Tier1"))
+            {
+                number.Add(100, TORTextHelper.GetTextObject("tor_stats_tier1_text", "Tier1"));
+            }
+            else if (info.AcquiredAttributes.Contains("Tier2"))
+            {
+                number.Add(150, TORTextHelper.GetTextObject("tor_stats_tier2_text", "Tier2"));
+            }
+            else if (info.AcquiredAttributes.Contains("Tier3"))
+            {
+                number.Add(200, TORTextHelper.GetTextObject("tor_stats_tier3_text", "Tier3"));
+            }
+            else if (info.AcquiredAttributes.Contains("Tier4"))
+            {
+                number.Add(300, TORTextHelper.GetTextObject("tor_stats_tier4_text", "Tier4"));
+            }
+            if (hero.IsVampire() && !hero.IsHumanPlayerCharacter)
+            {
+                number.Add(100, TORTextHelper.GetTextObject("tor_stats_vampire_body_text", "Vampire body"));
+            }
+
+            if (hero.HasAttribute(CharacterAttributes.EVERCHOSEN))
+            {
+                number.Add(2000, TORTextHelper.GetTextObject("tor_stats_everchosen_text", "Everchosen"));
+            }
+
+            if (hero.IsOrion())
+            {
+                number.Add(3000, TORTextHelper.GetTextObject("tor_stats_orion_text", "Orion"));
+            }
+
+            if (hero.HasAttribute(CharacterAttributes.TOUGH))
+            {
+                number.Add(100, TORTextHelper.GetTextObject("tor_stats_tough_text", "Tough"));
+            }
+
+            if (hero.HasAnyCareer())
+            {
+                CareerHelper.ApplyBasicCareerPassives(hero, ref number, PassiveEffectType.Health, false);
+            }
+
+            if (hero.HasAttribute(CharacterAttributes.GIFT_OF_NURGLE))
+            {
+                number.Add(20, TORTextHelper.GetTextObject("tor_stats_gift_of_nurgle_text", "Gift of Nurgle"));
+            }
+        }
+
+        /// <summary>
+        /// The player's own career choices, spent on their companions.
+        /// </summary>
+        private void AddCompanionCareerHealth(ref ExplainedNumber number, Hero hero)
+        {
+            if (Hero.MainHero.HasCareerChoice("GuiltyByAssociationPassive3"))
+            {
+                var choice = TORCareerChoices.GetChoice("GuiltyByAssociationPassive3");
+                number.Add(choice.GetPassiveValue(), choice.BelongsToGroup.Name);
+            }
+
+            if (Hero.MainHero.HasCareerChoice("CommanderPassive4"))
+            {
+                var choice = TORCareerChoices.GetChoice("CommanderPassive4");
+                number.Add(choice.GetPassiveValue(), choice.BelongsToGroup.Name);
+            }
+
+            if (Hero.MainHero.HasCareerChoice("EnvoyOfTheLadyPassive2"))
+            {
+                if (hero.IsBretonnianKnight())
+                {
+                    var choice = TORCareerChoices.GetChoice("EnvoyOfTheLadyPassive2");
+                    number.AddFactor(choice.GetPassiveValue(), choice.BelongsToGroup.Name);
+                }
+            }
+
+            if (Hero.MainHero.HasCareerChoice("HolyCrusaderPassive2") &&
+                hero.PartyBelongedTo == MobileParty.MainParty &&
+                hero.IsBretonnianKnight())
+            {
+                var choice = TORCareerChoices.GetChoice("HolyCrusaderPassive2");
+                var knightCount = MobileParty.MainParty.GetMemberHeroes().CountQ(knight => knight.IsBretonnianKnight());
+                number.Add(knightCount * choice.GetPassiveValue(), choice.BelongsToGroup.Name);
+            }
+
+            if (Hero.MainHero.HasCareerChoice("ForHearthAndHomePassive2"))
+            {
+                var equipment = hero.CharacterObject.GetCharacterEquipment();
+                var choice = TORCareerChoices.GetChoice("ForHearthAndHomePassive2");
+                var traitedItemCount = equipment.CountQ(item => item.HasAnyTrait());
+                number.Add(traitedItemCount * (int)choice.GetPassiveValue(), choice.BelongsToGroup.Name);
+            }
+
+            // BestofDaBestPassive4: Orc Big Bosses gain 100 health
+            if (Hero.MainHero.HasCareerChoice("BestofDaBestPassive4"))
+            {
+                if (hero.HasAttribute(CharacterAttributes.BIG_BOSS))
+                {
+                    var choice = TORCareerChoices.GetChoice("BestofDaBestPassive4");
+                    number.Add(choice.GetPassiveValue(), choice.BelongsToGroup.Name);
+                }
+            }
+
+            // Orc Shaman: +70 HP for Shaman Boss companion
+            if (Hero.MainHero.HasCareerChoice("GorkAnMorkAreWatchinPassive4"))
+            {
+                if (hero.HasAttribute(CharacterAttributes.SHAMAN_BOSS))
+                {
+                    var choice = TORCareerChoices.GetChoice("GorkAnMorkAreWatchinPassive4");
+                    number.Add(choice.GetPassiveValue(), choice.BelongsToGroup.Name);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Wood elf forest harmony, Oak of Ages upgrades and tree symbols. Reaches the player and
+        /// anyone travelling in their party.
+        /// </summary>
+        private void AddAsraiHealth(ref ExplainedNumber number, Hero hero)
+        {
+            if (Hero.MainHero.Culture.StringId == TORConstants.Cultures.ASRAI && hero.PartyBelongedTo != null && (hero.PartyBelongedTo.IsMainParty || hero == Hero.MainHero))
+            {
+
+                if (!Hero.MainHero.HasAttribute(CharacterAttributes.WE_WANDERER_SYMBOL))
+                {
+                    // Forest harmony is a player-owned resource everywhere else it is read
+                    // (ForestHarmonyHelper.GetForestHarmonyInfo), and the main party's leader is
+                    // always the player - reading it directly also removes a null LeaderHero path.
+                    var level = Hero.MainHero.GetForestHarmonyLevel();
+                    switch (level)
+                    {
+                        case ForestHarmonyLevel.Harmony: break;
+                        case ForestHarmonyLevel.Unbound:
+                            number.AddFactor(ForestHarmonyHelper.HealthDebuffUnBound, GameTexts.FindText("tor_forest_harmony_level", ForestHarmonyLevel.Unbound.ToString()));
+                            break;
+                        case ForestHarmonyLevel.Bound:
+                            number.AddFactor(ForestHarmonyHelper.HealthDebuffBound, GameTexts.FindText("tor_forest_harmony_level", ForestHarmonyLevel.Bound.ToString()));
+                            break;
+                    }
+                }
+
+                // 10% per unlocked upgrade, as one tooltip line rather than one per upgrade.
+                var settlementBehavior = Campaign.Current.GetCampaignBehavior<TORCustomSettlementCampaignBehavior>();
+                var oakUpgrades = settlementBehavior?.GetUnlockedOakUpgradeCategory("WEHealthUpgrade");
+                if (oakUpgrades != null && oakUpgrades.Count > 0)
+                {
+                    number.AddFactor(0.1f * oakUpgrades.Count, TORTextHelper.GetTextObject("tor_stats_oak_of_ages_text", "Oak of Ages"));
+                }
+
+                if (Hero.MainHero.HasAttribute(CharacterAttributes.WE_WARDANCER_SYMBOL))
+                {
+                    number.AddFactor(0.25f, ForestHarmonyHelper.TreeSymbolText("WEWardancerSymbol"));
+                }
+
+                if (hero == Hero.MainHero && Hero.MainHero.HasAttribute(CharacterAttributes.WE_DURTHU_SYMBOL))
+                {
+                    number.AddFactor(0.10f, ForestHarmonyHelper.TreeSymbolText("WEDurthuSymbol"));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Runs for every hero, including those without extended info.
+        /// </summary>
+        private void AddUniversalHeroHealth(ref ExplainedNumber number, Hero hero)
+        {
             if (hero.GetPerkValue(TORPerks.Faith.Devotee))
             {
-                number.Add(TORPerks.Faith.Devotee.PrimaryBonus * hero.GetAttributeValue(TORAttributes.Discipline), new TextObject("Perks"));
+                number.Add(TORPerks.Faith.Devotee.PrimaryBonus * hero.GetAttributeValue(TORAttributes.Discipline), TORTextHelper.GetTextObject("tor_stats_perks_text", "Perks"));
             }
 
             var healthFromEquipment = hero.GetAggregatedStatEffectFromEquipment(ItemTraitStatType.HealthMax);
@@ -290,11 +349,10 @@ namespace TOR_Core.Models
             }
 
             var model = Campaign.Current.Models.CampaignTimeModel;
-            if ((bool)(model?.CampaignStartTime.IsNow))
+            if (model != null && model.CampaignStartTime.IsNow)
             {
                 hero.HitPoints = (int)number.ResultNumber;
             }
-            return number;
         }
     }
 }

--- a/ModuleData/tor_strings.xml
+++ b/ModuleData/tor_strings.xml
@@ -511,6 +511,18 @@
   <string id="tor_stats_tier3_text" text="{=str_tor_stats_tier3_text}Tier3" />
   <string id="tor_stats_tier4_text" text="{=str_tor_stats_tier4_text}Tier4" />
   <string id="tor_stats_vampire_body_text" text="{=str_tor_stats_vampire_body_text}Vampire body" />
+  <string id="tor_stats_dwarf_bonus_text" text="{=str_tor_stats_dwarf_bonus_text}Dwarf bonus" />
+  <string id="tor_stats_goblin_bonus_text" text="{=str_tor_stats_goblin_bonus_text}Goblin frailty" />
+  <string id="tor_stats_orc_bonus_text" text="{=str_tor_stats_orc_bonus_text}Orc bonus" />
+  <string id="tor_stats_troop_tier_text" text="{=str_tor_stats_troop_tier_text}Troop tier" />
+  <string id="tor_stats_undead_body_text" text="{=str_tor_stats_undead_body_text}Undead body" />
+  <string id="tor_stats_necromancer_champion_text" text="{=str_tor_stats_necromancer_champion_text}Necromantic empowerment" />
+  <string id="tor_stats_everchosen_text" text="{=str_tor_stats_everchosen_text}Everchosen" />
+  <string id="tor_stats_orion_text" text="{=str_tor_stats_orion_text}Orion" />
+  <string id="tor_stats_tough_text" text="{=str_tor_stats_tough_text}Tough" />
+  <string id="tor_stats_gift_of_nurgle_text" text="{=str_tor_stats_gift_of_nurgle_text}Gift of Nurgle" />
+  <string id="tor_stats_oak_of_ages_text" text="{=str_tor_stats_oak_of_ages_text}Oak of Ages" />
+  <string id="tor_stats_perks_text" text="{=str_tor_stats_perks_text}Perks" />
 
   <!-- Healing & Other Bonuses -->
   <string id="tor_healing_shallya_seal_text" text="{=str_tor_healing_shallya_seal_text}Shallya Seal" />

--- a/docs/character-stats-refactor-pr-notes.md
+++ b/docs/character-stats-refactor-pr-notes.md
@@ -1,0 +1,59 @@
+# TORCharacterStatsModel — health calculation refactor
+
+`CSharpSourceCode/Models/TORCharacterStatsModel.cs` (+238/−168), `ModuleData/tor_strings.xml` (+12).
+
+## Two real bugs
+
+**Necromancer champion doubled instead of dying.** The fallback taken when the player's career
+ability scaling can't be read logged "Champion being set to 1 hp and being left to die", then ran
+`value = number.ResultNumber - 1; number.Add(value)` — which yields `2R−1`, roughly double health.
+It now replaces the number outright (`new ExplainedNumber(1f)`) and returns. The log message was
+right; the arithmetic was missing a sign.
+
+**`(bool)(model?.CampaignStartTime.IsNow)` throws when the model is null** — the `?.` produces a
+null `bool?` and the unboxing cast fails, so the null-safe operator made the crash it looked like
+it was preventing. Now `model != null && model.CampaignStartTime.IsNow`.
+
+## Why the split is shaped the way it is
+
+Heroes are classified Player / Companion / Lord (`GetHeroKind`), with troops branching earlier.
+Forest harmony deliberately does **not** hang off that switch: your own clan's lords can ride in
+the main party and are not `IsPlayerCompanion`, so gating the Asrai block on hero kind would have
+silently stripped their harmony debuff. It stays keyed on party membership.
+
+Race bonuses were duplicated verbatim in the troop and hero paths (`IsDwarf(Hero)` and
+`IsDwarf(CharacterObject)` are byte-identical), so they hoist into `AddRaceHealth` for all four
+categories. Reordering is safe because `AddFactor` applies to the accumulated total regardless of
+insertion point; the one order-sensitive read was the champion block, which stays last.
+
+I did **not** convert the race checks to a static dictionary keyed on race id.
+`FaceGen.GetRaceOrDefault` returns 0 for an unregistered race, so a static initializer running
+before races load would throw `TypeInitializationException` on a duplicate key.
+
+The `IsTreeman()` / `else if (IsTreeSpirit())` pairing looks like a bug and isn't. `tor_we_treeman`
+carries `race="large_humanoid_monster"` *and* the `TreeSpirit` attribute
+(`tor_troopdefinitions.xml:1467`, `tor_extendedunitproperties.xml:1274`), so the `else` is what
+keeps treemen on +1000 rather than +1100. Commented in place.
+
+## Behaviour changes a reviewer should weigh
+
+Numbers are unchanged everywhere except the two bugs above. What did change:
+
+- Forest harmony now reads `Hero.MainHero.GetForestHarmonyLevel()` instead of
+  `hero.PartyBelongedTo.LeaderHero.GetForestHarmonyLevel()`. Same hero in every reachable case,
+  matches how `ForestHarmonyHelper` reads it everywhere else, and removes a null `LeaderHero`
+  dereference.
+- Oak of Ages was `AddFactor(0.1f)` once per unlocked upgrade, producing N identical tooltip lines.
+  Now one line at `0.1f * count` — same factor, one row. `GetCampaignBehavior` is also null-guarded.
+- Every bare `Add(…)` gained a description, so the health tooltip now explains Everchosen, Orion,
+  Tough, the troop tier step, the undead penalty and the three race bonuses instead of showing an
+  unattributed delta. Twelve new `tor_stats_*` strings.
+
+## Verification
+
+There is no build path on the dev machine that resolves this project's PackageReferences
+(non-SDK csproj, no Visual Studio MSBuild), so a clean build was not obtainable — `dotnet build`
+reports ~2.3k `CS0246`s repo-wide. Roslyn still binds every file, and
+`TORCharacterStatsModel.cs`'s only diagnostic is the same line-1 `using NLog;` error 90 other
+files get. That is inference, not a green build. Manual scenarios in
+`character-stats-refactor-test-plan.md` are the real gate.

--- a/docs/character-stats-refactor-test-plan.md
+++ b/docs/character-stats-refactor-test-plan.md
@@ -1,0 +1,121 @@
+# Test plan — TORCharacterStatsModel health refactor
+
+Manual, in-game. Automated coverage is not available for game models in this repo.
+
+## Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Baseline | Capture values with the committed `bin/Win64_Shipping_Client/TOR_Core.dll` **before** overwriting it | Every scenario except 3b and 15 asserts "unchanged", which needs a before |
+| Save to use | One existing campaign, not a fresh start | Exercises the save-compat path and gives real companions/lords to inspect |
+| Second save | One Asrai (wood elf) campaign | Scenarios 7, 8, 13, 14 are unreachable otherwise |
+| Numbers vs tooltips | Both recorded | Numbers must be identical; tooltip rows are the intended change |
+| Not verified | Exact float equality on `AddFactor` chains | Displayed HP is rounded; match to the integer shown |
+| Not verified | Treeman +1100 | Confirmed as intended at +1000 from troop data; no change made |
+
+## Run record
+
+| # | Scenario | Baseline | After | Pass/fail | Notes |
+|---|---|---|---|---|---|
+| 1 | Troop tier steps | | | | |
+| 2 | Undead troop penalty | | | | |
+| 3a | Champion, scaling present | | | | |
+| 3b | Champion, scaling missing | | | | |
+| 4 | Race troops | | | | |
+| 5 | Monster races | | | | |
+| 6 | Player vampire exclusion | | | | |
+| 7 | Asrai harmony debuff | | | | |
+| 8 | Tree symbols | | | | |
+| 9 | Companion career passives | | | | |
+| 10 | Holy Crusader scaling | | | | |
+| 11 | For Hearth and Home scaling | | | | |
+| 12 | Lord attribute bonuses | | | | |
+| 13 | Clan lord in main party | | | | |
+| 14 | Oak of Ages | | | | |
+| 15 | Campaign start HP | | | | |
+| 16 | Tooltip strings | | | | |
+| 17 | Save compatibility | | | | |
+
+## Scenarios
+
+### Troop path
+
+**1. Troop tier steps.** Field one tier 0, one tier 4 and one tier 6+ troop. Max HP must match
+baseline exactly. The tier contribution now shows as a "Troop tier" row where the breakdown is
+displayed; the total must not move.
+
+**2. Undead troop penalty.** A non-hero undead troop without `NecromancerChampion` keeps its −25.
+An undead *hero* must be unaffected by this line — it is troop-only and always was.
+
+**3a. Necromancer champion, scaling present.** Play a Necromancer, raise a champion in a mission
+with the career ability available. Champion HP must equal baseline.
+
+**3b. Necromancer champion, scaling missing.** *This is the bug fix.* Reach the fallback — easiest
+is a champion present after the player agent is gone, or a champion spawned without the
+Necromancer career (cheat-spawn). Expected: champion has **1 HP** and dies to anything. Before this
+change it had roughly double its normal health. Confirm the log line "Champion being set to 1 hp"
+appears in `Logs/` and that the outcome now matches it.
+
+**4. Race troops.** One dwarf, one goblin, one orc troop: +20 / −20 / +40 against baseline. The
+same three values must also still apply to *heroes* of those races — that block was duplicated and
+is now shared, so check one dwarf hero too.
+
+**5. Monster races.** Minotaur +350, troll +450, treeman +1000, dryad +100. Treeman must be
+**+1000, not +1100** — it carries the `TreeSpirit` attribute as well as the monster race, and the
+`else if` that keeps the two from stacking is intentional.
+
+### Player
+
+**6. Player vampire exclusion.** A vampire player character must **not** receive the +100 "Vampire
+body" bonus; a vampire companion or lord must. The exclusion still uses `IsHumanPlayerCharacter`.
+
+**7. Asrai harmony debuff.** Asrai save. At Unbound, health factor −35%; at Bound, −15%; at
+Harmony, none. Check on the player **and** on a companion in the main party — both read the
+player's harmony level. With the Wanderer symbol active, no debuff at all.
+
+**8. Tree symbols.** Wardancer symbol: +25% to the player and to main-party members. Durthu
+symbol: +10% to the **player only**, and it now carries a "Durthu Symbol" tooltip row where it
+previously showed an unlabelled factor.
+
+### Companion
+
+**9. Companion career passives.** With the relevant player career choices unlocked, confirm each
+still lands on a companion: `GuiltyByAssociationPassive3`, `CommanderPassive4`,
+`EnvoyOfTheLadyPassive2` (Bretonnian knight only, applied as a factor), `BestofDaBestPassive4`
+(Big Boss only), `GorkAnMorkAreWatchinPassive4` (Shaman Boss only). None may apply to a
+non-companion hero.
+
+**10. Holy Crusader scaling.** With `HolyCrusaderPassive2`, a Bretonnian knight companion in the
+main party gains `knight count × passive value`. Add a second knight and confirm the bonus grows by
+exactly one step. The counting was rewritten from `Where().Count()` to `CountQ` — same result
+expected.
+
+**11. For Hearth and Home scaling.** With `ForHearthAndHomePassive2`, the bonus equals
+`traited item count × passive value`. Swap one enchanted item in and out and confirm one step of
+change. Rewritten from `WhereQ().Sum()` to `CountQ() ×`.
+
+### Lord
+
+**12. Lord attribute bonuses.** An AI lord with `Everchosen` gets +2000, Orion +3000, `Tough` +100
+— unchanged, but each now shows a labelled tooltip row.
+
+**13. Clan lord in the main party.** *Highest-risk regression.* Put a lord of your own clan (not a
+wanderer companion — they are not `IsPlayerCompanion`) into the main party in the Asrai save. They
+must still receive the forest harmony debuff and the Oak of Ages factor, exactly as before. They
+must **not** receive the companion-only career passives from scenario 9.
+
+### Cross-cutting
+
+**14. Oak of Ages.** With two or more `WEHealthUpgrade` upgrades unlocked, the health factor is
+`0.1 × count` as a **single** tooltip row. Previously it was one row per upgrade with the same
+total. Verify the total is unchanged and only the row count differs.
+
+**15. Campaign start HP.** Start a new campaign and confirm heroes begin at full computed max HP.
+
+**16. Tooltip strings.** Every new row renders readable text, not a raw id or a blank: Troop tier,
+Undead body, Necromantic empowerment, Everchosen, Orion, Tough, Dwarf bonus, Goblin frailty, Orc
+bonus, Gift of Nurgle, Oak of Ages, Perks, Durthu Symbol.
+
+**17. Save compatibility.** Load a campaign saved with the previous build. No saved fields were
+added or renamed, so this should be clean — confirm no load error and no HP shift on existing
+heroes.


### PR DESCRIPTION
Reorganises `MaxHitpoints` into four character categories — Troop, Player, Companion, Lord —
and fixes two bugs found on the way. Numbers are unchanged everywhere except those two fixes.

## Bugs

**Necromancer champion doubled instead of dying.** The fallback for unreadable career-ability
scaling logged "Champion being set to 1 hp and being left to die", then did
`value = ResultNumber - 1; Add(value)` — yielding `2R−1`, roughly double health. It now replaces
the number outright and returns. The log message was right; the arithmetic was missing a sign.

**`(bool)(model?.CampaignStartTime.IsNow)` throws when the model is null** — the `?.` yields a null
`bool?` and the unboxing cast fails, so the null-safe operator caused the crash it looked like it
was preventing.

## Why the split is shaped this way

Forest harmony deliberately does **not** hang off the hero-kind switch. Your own clan's lords can
ride in the main party and are not `IsPlayerCompanion`, so keying the Asrai block on kind would
have silently stripped their harmony debuff. It stays keyed on party membership.

Race bonuses were duplicated verbatim across the troop and hero paths (`IsDwarf(Hero)` and
`IsDwarf(CharacterObject)` are byte-identical) and now apply once for all four categories.
Reordering is safe — `AddFactor` applies to the accumulated total regardless of insertion point,
and the one order-sensitive read (the champion block) stays last.

Not done, deliberately: a static race→bonus dictionary. `FaceGen.GetRaceOrDefault` returns 0 for
an unregistered race, so a static initialiser running before races load would throw
`TypeInitializationException` on a duplicate key.

The `IsTreeman()` / `else if (IsTreeSpirit())` pairing looks like a bug and isn't. `tor_we_treeman`
carries `race="large_humanoid_monster"` *and* the `TreeSpirit` attribute, so the `else` is what
keeps treemen at +1000 rather than +1100. Commented in place.

## Other behaviour deltas

- Forest harmony reads `Hero.MainHero.GetForestHarmonyLevel()` rather than
  `PartyBelongedTo.LeaderHero...` — same hero in every reachable case, matches how
  `ForestHarmonyHelper` reads it elsewhere, and removes a null `LeaderHero` dereference.
- Oak of Ages was one `AddFactor(0.1f)` per unlocked upgrade, producing N identical tooltip rows.
  Now one row at `0.1f × count` — same factor.
- Every bare `Add(…)` gained a description, so the tooltip explains Everchosen, Orion, Tough, the
  troop tier step, the undead penalty and the race bonuses instead of showing an unattributed
  delta. Twelve new `tor_stats_*` strings.

## Testing

Not yet run. No build path on the dev machine resolves this project's PackageReferences (non-SDK
csproj, no VS MSBuild), so a clean build wasn't obtainable; Roslyn binds the file with no
diagnostics of its own. 17 manual scenarios in `docs/character-stats-refactor-test-plan.md` —
scenario 3b (champion fallback now 1 HP) and 13 (clan lord in main party keeps harmony) are the
ones that matter. Save-compatible: no saved fields added or renamed.